### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "66ee7f9a70b180246fd6dab0",
+  "nxCloudId": "66ee80108518fa42bb84a0fb",
   "plugins": [
     {
       "plugin": "@nx/vite/plugin",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/65e72757b35f78b0f34130c5/workspaces/66ee80108518fa42bb84a0fb

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.